### PR TITLE
Improve appbar and home view mobile view

### DIFF
--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -3,3 +3,31 @@
 @tailwind components;
 
 @tailwind utilities;
+
+.responsive-wrap {
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+}
+
+.responsive-nowrap {
+    display: flex;
+    flex-wrap: nowrap;
+    justify-content: space-between;
+}
+
+.responsive-child {
+    width: 100%;
+    justify-content: center;
+    margin: 10px auto;
+}
+
+@media screen and (min-width: 640px) {
+    .responsive-wrap {
+        flex-wrap: nowrap;
+    }
+
+    .responsive-child {
+        width: auto;
+    }
+}

--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -3,31 +3,3 @@
 @tailwind components;
 
 @tailwind utilities;
-
-.responsive-wrap {
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
-}
-
-.responsive-nowrap {
-    display: flex;
-    flex-wrap: nowrap;
-    justify-content: space-between;
-}
-
-.responsive-child {
-    width: 100%;
-    justify-content: center;
-    margin: 10px auto;
-}
-
-@media screen and (min-width: 640px) {
-    .responsive-wrap {
-        flex-wrap: nowrap;
-    }
-
-    .responsive-child {
-        width: auto;
-    }
-}

--- a/src/components/Appbar.vue
+++ b/src/components/Appbar.vue
@@ -1,17 +1,17 @@
 <template>
-  <div class="flex justify-between responsive-wrap">
-    <div class="responsive-child">
+  <div class="flex flex-auto flex-wrap justify-center md:justify-between md:flex-nowrap">
+    <div class="px-8 py-2 w-full md:w-auto">
       <router-link
         class="my-auto font-bold text-gray-600 text-xl"
         :to="`/${$i18n.locale}/`"
         >KéMeet</router-link
       >
     </div>
-    <div class="flex space-x-2 my-auto responsive-child">
+    <div class="flex px-8 py-2 space-x-2 my-auto">
       <div>Design Check-in Meeting</div>
       <div class="bg-gray-300 p-1 text-xs rounded-lg">14:02</div>
     </div>
-    <div class="flex space-x-2 responsive-child">
+    <div class="flex px-8 py-2 space-x-2">
       <div class="my-auto">
         <button><span class="material-icons"> light_mode </span></button>
       </div>

--- a/src/components/Appbar.vue
+++ b/src/components/Appbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-auto flex-wrap justify-center md:justify-between md:flex-nowrap">
+  <div class="flex flex-auto flex-wrap justify-center items-center md:justify-between md:flex-nowrap">
     <div class="px-8 py-2 w-full md:w-auto">
       <router-link
         class="my-auto font-bold text-gray-600 text-xl"

--- a/src/components/Appbar.vue
+++ b/src/components/Appbar.vue
@@ -1,17 +1,17 @@
 <template>
-  <div class="flex justify-between">
-    <div>
+  <div class="flex justify-between responsive-wrap">
+    <div class="responsive-child">
       <router-link
         class="my-auto font-bold text-gray-600 text-xl"
         :to="`/${$i18n.locale}/`"
         >KéMeet</router-link
       >
     </div>
-    <div class="flex space-x-2 my-auto">
+    <div class="flex space-x-2 my-auto responsive-child">
       <div>Design Check-in Meeting</div>
       <div class="bg-gray-300 p-1 text-xs rounded-lg">14:02</div>
     </div>
-    <div class="flex space-x-2">
+    <div class="flex space-x-2 responsive-child">
       <div class="my-auto">
         <button><span class="material-icons"> light_mode </span></button>
       </div>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -3,7 +3,7 @@
     <div class="w-7/12 mx-auto">
       {{ $t("introText") }}
     </div>
-    <div class="flex space-x-2 justify-center mt-16 responsive-wrap">
+    <div class="flex flex-wrap space-x-2 justify-center mt-16">
       <div class="mt-2 mb-2">
         <input
           class="border rounded-sm p-2 w-56"
@@ -12,7 +12,7 @@
           id="room-input"
         />
       </div>
-      <div class="responsive-nowrap space-x-2">
+      <div class="flex flex-nowrap space-x-2">
         <div class="mt-2 mb-2">
           <router-link
             class="bg-red-400 text-white font-medium py-2 px-3 rounded-lg"

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -3,8 +3,8 @@
     <div class="w-7/12 mx-auto">
       {{ $t("introText") }}
     </div>
-    <div class="flex space-x-2 justify-center mt-16">
-      <div>
+    <div class="flex space-x-2 justify-center mt-16 responsive-wrap">
+      <div class="mt-2 mb-2">
         <input
           class="border rounded-sm p-2 w-56"
           v-model="roomId"
@@ -12,21 +12,24 @@
           id="room-input"
         />
       </div>
-      <div class="mt-2">
-        <router-link
-          class="bg-red-400 text-white font-medium py-2 px-3 rounded-lg"
-          :to="`/${$i18n.locale}/room/${roomId}`"
-        >
-          {{ $t("meetingStart.joinMeeting") }}
-        </router-link>
-      </div>
-      <div class="mt-2">
-        <router-link
-          class="bg-green-500 text-white font-medium py-2 px-3 rounded-lg"
-          :to="`/${$i18n.locale}/room/${newMeetingRoomId}`"
-        >
-          {{ $t("meetingStart.newMeeting") }}
-        </router-link>
+      <div class="responsive-nowrap space-x-2">
+        <div class="mt-2 mb-2">
+          <router-link
+            class="bg-red-400 text-white font-medium py-2 px-3 rounded-lg"
+            :to="`/${$i18n.locale}/room/${roomId}`"
+          >
+            {{ $t("meetingStart.joinMeeting") }}
+          </router-link>
+        </div>
+        <div class="mt-2 mb-2">
+          <router-link
+            class="bg-green-500 text-white font-medium py-2 px-3 rounded-lg"
+            :to="`/${$i18n.locale}/room/${newMeetingRoomId}`"
+          >
+            {{ $t("meetingStart.newMeeting") }}
+          </router-link>
+        </div>
+
       </div>
     </div>
     <div class="w-7/12 mx-auto mt-10 text-gray-500">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,9 @@ module.exports = {
       borderColor: {
         
       },
+      screens: {
+        'md':'750px',
+      }
     },
   },
   variants: {


### PR DESCRIPTION
Hello! I came across this issue and had some suggestions for improving the responsiveness of the app on mobile. The suggested changes in this pull request only affect the appnav component and the home view (there are still a few other components/views that need adjusting as well.)

Partially fixes #1 

**Regular layout**
<img width="760" alt="Screen Shot 2021-11-05 at 4 31 14 PM" src="https://user-images.githubusercontent.com/84106309/140574874-caa9dc86-e867-40d0-aad8-dabb4204fe03.png">

**Layout at 600px viewport width**
<img width="597" alt="Screen Shot 2021-11-05 at 4 31 31 PM" src="https://user-images.githubusercontent.com/84106309/140574890-cd9e3c53-e3c5-4fc2-bb00-224231bb1b75.png">

**Layout at 375 viewport width**
<img width="373" alt="Screen Shot 2021-11-05 at 4 31 51 PM" src="https://user-images.githubusercontent.com/84106309/140574913-acfc101b-e32f-443a-b933-855851ad0ef5.png">


